### PR TITLE
Add DataValues organization to team related section

### DIFF
--- a/data/repositories.json
+++ b/data/repositories.json
@@ -56,6 +56,7 @@
     "https://gerrit.wikimedia.org/r/admin/repos/mediawiki/extensions/WikibaseMediaInfo",
     "https://gerrit.wikimedia.org/r/admin/repos/wikidata/query/blazegraph",
     "https://gerrit.wikimedia.org/r/admin/repos/wikidata/query/rdf",
-    "https://github.com/Wikidata/WikibaseImport"
+    "https://github.com/Wikidata/WikibaseImport",
+    "https://github.com/DataValues"
   ]
 }


### PR DESCRIPTION
The packages in the DataValues organization are used in Wikibase
and we often end up submitting patches to them.